### PR TITLE
Allow runtime configuration via `IATIKIT_CONFIG_DATASOURCES_ZIP_URL` environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Allow runtime configuration of ZIP file containing the IATI XML files via `IATIKIT_CONFIG_DATASOURCES_ZIP_URL` environment variable as well as `iatikit.ini` file.
 
 ## [3.5.0] – 2025-06-14
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -46,3 +46,5 @@ By default iatikit will download all the IATI data from the Code for IATI Data D
     zip_url=URL_OF_ZIP_FILE
 
 The `iatikit.ini` file should be placed in the directory from which python is launched to run the client application (i.e., the application which uses `iatikit`). 
+
+You can also pass the `IATIKIT_CONFIG_DATASOURCES_ZIP_URL` environment variable.

--- a/iatikit/utils/config.py
+++ b/iatikit/utils/config.py
@@ -1,4 +1,5 @@
 from os.path import join
+from os import getenv
 
 from configparser import ConfigParser
 
@@ -6,7 +7,7 @@ from configparser import ConfigParser
 def _load_config():
     defaults = {
         'data_sources': {
-            'zip_url': '',
+            'zip_url': getenv("IATIKIT_CONFIG_DATASOURCES_ZIP_URL",""),
         },
         'paths': {
             'registry': join('__iatikitcache__', 'registry'),


### PR DESCRIPTION
as well as `iatikit.ini` file.

This is because using iatikit.ini can be difficult, you have to make sure the file is in the current working directory and that is brittle if the current working directory changes.

So add another option, a env var, that can easily be set with no worries about the current working directory.